### PR TITLE
Allow to write output into a directory directly instead of a ZIP file

### DIFF
--- a/src/java/com/google/cloud/bigquery/dwhassessment/extractiontool/config/BaseModule.java
+++ b/src/java/com/google/cloud/bigquery/dwhassessment/extractiontool/config/BaseModule.java
@@ -24,7 +24,7 @@ import com.google.cloud.bigquery.dwhassessment.extractiontool.db.ScriptRunnerImp
 import com.google.cloud.bigquery.dwhassessment.extractiontool.dbscripts.InternalScriptLoader;
 import com.google.cloud.bigquery.dwhassessment.extractiontool.dbscripts.ScriptLoader;
 import com.google.cloud.bigquery.dwhassessment.extractiontool.dumper.DataEntityManager;
-import com.google.cloud.bigquery.dwhassessment.extractiontool.dumper.DataEntityManagerZipImpl;
+import com.google.cloud.bigquery.dwhassessment.extractiontool.dumper.DataEntityManagerFactory;
 import com.google.cloud.bigquery.dwhassessment.extractiontool.executor.ExtractExecutor;
 import com.google.cloud.bigquery.dwhassessment.extractiontool.executor.ExtractExecutorImpl;
 import com.google.cloud.bigquery.dwhassessment.extractiontool.subcommand.AboutSubcommand;
@@ -35,14 +35,10 @@ import com.google.inject.Key;
 import com.google.inject.Provides;
 import com.google.inject.TypeLiteral;
 import com.google.inject.multibindings.Multibinder;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
 import java.nio.file.Path;
 import java.util.concurrent.Callable;
 import java.util.function.Function;
 import java.util.function.Supplier;
-import java.util.zip.ZipOutputStream;
 import javax.inject.Provider;
 import javax.inject.Singleton;
 
@@ -86,16 +82,7 @@ public final class BaseModule extends AbstractModule {
   @Provides
   @Singleton
   Function<Path, DataEntityManager> dataEntityManagerFactory() {
-    return path -> {
-      File bundledZipFile = new File(path.toFile(), "assessment.zip");
-      try {
-        return new DataEntityManagerZipImpl(
-            new ZipOutputStream(new FileOutputStream(bundledZipFile)));
-      } catch (IOException e) {
-        throw new IllegalStateException(
-            "Failed to initialize the dataEntityManagerFactory for path: " + path.toString());
-      }
-    };
+    return new DataEntityManagerFactory();
   }
 
   @Provides

--- a/src/java/com/google/cloud/bigquery/dwhassessment/extractiontool/dumper/BUILD
+++ b/src/java/com/google/cloud/bigquery/dwhassessment/extractiontool/dumper/BUILD
@@ -18,4 +18,7 @@ package(default_visibility = ["//src:internal"])
 java_library(
     name = "dumper",
     srcs = glob(["*.java"]),
+    deps = [
+        "@maven//:com_google_guava_guava_30_1_1_jre",
+    ],
 )

--- a/src/java/com/google/cloud/bigquery/dwhassessment/extractiontool/dumper/DataEntityManager.java
+++ b/src/java/com/google/cloud/bigquery/dwhassessment/extractiontool/dumper/DataEntityManager.java
@@ -17,6 +17,7 @@
 package com.google.cloud.bigquery.dwhassessment.extractiontool.dumper;
 
 import java.io.Closeable;
+import java.io.IOException;
 import java.io.OutputStream;
 
 /** Interface to manage data entity, e.g. AVRO files. */
@@ -27,5 +28,5 @@ public interface DataEntityManager extends Closeable {
    *
    * @param name The name of the output entity.
    */
-  OutputStream getEntityOutputStream(String name);
+  OutputStream getEntityOutputStream(String name) throws IOException;
 }

--- a/src/java/com/google/cloud/bigquery/dwhassessment/extractiontool/dumper/DataEntityManagerDirectoryImpl.java
+++ b/src/java/com/google/cloud/bigquery/dwhassessment/extractiontool/dumper/DataEntityManagerDirectoryImpl.java
@@ -1,0 +1,24 @@
+package com.google.cloud.bigquery.dwhassessment.extractiontool.dumper;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/** A data entity manager that writes files to a given directory. */
+public class DataEntityManagerDirectoryImpl implements DataEntityManager {
+
+  private final Path basePath;
+
+  public DataEntityManagerDirectoryImpl(Path basePath) {
+    this.basePath = basePath;
+  }
+
+  @Override
+  public OutputStream getEntityOutputStream(String name) throws IOException {
+    return Files.newOutputStream(basePath.resolve(name));
+  }
+
+  @Override
+  public void close() throws IOException {}
+}

--- a/src/java/com/google/cloud/bigquery/dwhassessment/extractiontool/dumper/DataEntityManagerFactory.java
+++ b/src/java/com/google/cloud/bigquery/dwhassessment/extractiontool/dumper/DataEntityManagerFactory.java
@@ -1,0 +1,26 @@
+package com.google.cloud.bigquery.dwhassessment.extractiontool.dumper;
+
+import com.google.common.base.Preconditions;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.function.Function;
+
+public class DataEntityManagerFactory implements Function<Path, DataEntityManager> {
+
+  @Override
+  public DataEntityManager apply(Path path) {
+    if (path.toString().endsWith(".zip")) {
+      Preconditions.checkArgument(
+          Files.isDirectory(path.getParent()), "%s is not a directory.", path.getParent());
+      try {
+        return new DataEntityManagerZipImpl(Files.newOutputStream(path));
+      } catch (IOException e) {
+        throw new IllegalStateException(
+            String.format("Failed to initialize the DataEntityManager for path: %s", path));
+      }
+    }
+    Preconditions.checkArgument(Files.isDirectory(path), "%s is not a directory.", path);
+    return new DataEntityManagerDirectoryImpl(path);
+  }
+}

--- a/src/javatests/com/google/cloud/bigquery/dwhassessment/extractiontool/dumper/BUILD
+++ b/src/javatests/com/google/cloud/bigquery/dwhassessment/extractiontool/dumper/BUILD
@@ -31,6 +31,7 @@ java_library(
     srcs = glob(["*Test.java"]),
     deps = [
         "//src/java/com/google/cloud/bigquery/dwhassessment/extractiontool/dumper",
+        "@maven//:com_google_guava_guava_30_1_1_jre",
         "@maven//:com_google_truth_truth",
         "@maven//:junit_junit",
         "@maven//:org_mockito_mockito_core",
@@ -38,9 +39,27 @@ java_library(
 )
 
 java_test(
+    name = "DataEntityManagerDirectoryImplTest",
+    size = "small",
+    test_class = "com.google.cloud.bigquery.dwhassessment.extractiontool.dumper.DataEntityManagerDirectoryImplTest",
+    runtime_deps = [
+        ":tests",
+    ],
+)
+
+java_test(
     name = "DataEntityManagerZipImplTest",
     size = "small",
     test_class = "com.google.cloud.bigquery.dwhassessment.extractiontool.dumper.DataEntityManagerZipImplTest",
+    runtime_deps = [
+        ":tests",
+    ],
+)
+
+java_test(
+    name = "DataEntityManagerFactoryTest",
+    size = "small",
+    test_class = "com.google.cloud.bigquery.dwhassessment.extractiontool.dumper.DataEntityManagerFactoryTest",
     runtime_deps = [
         ":tests",
     ],

--- a/src/javatests/com/google/cloud/bigquery/dwhassessment/extractiontool/dumper/DataEntityManagerDirectoryImplTest.java
+++ b/src/javatests/com/google/cloud/bigquery/dwhassessment/extractiontool/dumper/DataEntityManagerDirectoryImplTest.java
@@ -1,0 +1,53 @@
+package com.google.cloud.bigquery.dwhassessment.extractiontool.dumper;
+
+import static com.google.common.io.Files.asCharSource;
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.ImmutableMap;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class DataEntityManagerDirectoryImplTest {
+
+  private Path tmpDir;
+
+  @Before
+  public void setUp() throws IOException {
+    tmpDir = Files.createTempDirectory("data-entity-manager-directory-test");
+  }
+
+  @Test
+  public void testDataEntityManager() throws IOException {
+    DataEntityManager dataEntityManager = new DataEntityManagerDirectoryImpl(tmpDir);
+    try (OutputStream out = dataEntityManager.getEntityOutputStream("test1")) {
+      out.write("test1".getBytes(StandardCharsets.UTF_8));
+    }
+    try (OutputStream out = dataEntityManager.getEntityOutputStream("test2")) {
+      out.write("Hello There".getBytes(StandardCharsets.UTF_8));
+    }
+
+    assertThat(
+            Files.walk(tmpDir)
+                .filter(Files::isRegularFile)
+                .sorted()
+                .collect(
+                    ImmutableMap.toImmutableMap(
+                        path -> path.getFileName().toString(),
+                        path -> {
+                          try {
+                            return asCharSource(path.toFile(), StandardCharsets.UTF_8).read();
+                          } catch (IOException e) {
+                            throw new RuntimeException(e);
+                          }
+                        })))
+        .isEqualTo(ImmutableMap.of("test1", "test1", "test2", "Hello There"));
+  }
+}

--- a/src/javatests/com/google/cloud/bigquery/dwhassessment/extractiontool/dumper/DataEntityManagerFactoryTest.java
+++ b/src/javatests/com/google/cloud/bigquery/dwhassessment/extractiontool/dumper/DataEntityManagerFactoryTest.java
@@ -1,0 +1,36 @@
+package com.google.cloud.bigquery.dwhassessment.extractiontool.dumper;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.function.Function;
+import junit.framework.TestCase;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class DataEntityManagerFactoryTest extends TestCase {
+
+  private final Function<Path, DataEntityManager> factory = new DataEntityManagerFactory();
+  private Path tmpDir;
+
+  @Before
+  public void setUp() throws IOException {
+    tmpDir = Files.createTempDirectory("data-entity-manager-factory-test");
+  }
+
+  @Test
+  public void testApply_directory_success() {
+    assertThat(factory.apply(tmpDir)).isInstanceOf(DataEntityManagerDirectoryImpl.class);
+  }
+
+  @Test
+  public void testApply_zip_success() {
+    assertThat(factory.apply(tmpDir.resolve("foo.zip")))
+        .isInstanceOf(DataEntityManagerZipImpl.class);
+  }
+}

--- a/src/javatests/com/google/cloud/bigquery/dwhassessment/extractiontool/subcommand/ExtractSubcommandTest.java
+++ b/src/javatests/com/google/cloud/bigquery/dwhassessment/extractiontool/subcommand/ExtractSubcommandTest.java
@@ -33,7 +33,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Mock;
 import org.mockito.Mockito;
 import picocli.CommandLine;
 
@@ -239,6 +238,24 @@ public final class ExtractSubcommandTest {
         .isEqualTo(2);
     assertThat(writer.toString())
         .contains("--output must specify a directory, but '/does/not/exist' is not a directory.");
+  }
+
+  @Test
+  public void call_failOnIncorrectOutputZipPath() {
+    ExtractExecutor executor = Mockito.mock(ExtractExecutor.class);
+    CommandLine cmd = new CommandLine(new ExtractSubcommand(() -> executor));
+    StringWriter writer = new StringWriter();
+    cmd.setErr(new PrintWriter(writer));
+
+    assertThat(
+            cmd.execute(
+                "--db-address",
+                "jdbc:hsqldb:mem:my-animalclinic.example",
+                "--output",
+                "/does/not/exist/out.zip"))
+        .isEqualTo(2);
+    assertThat(writer.toString())
+        .contains("Parent path of --output '/does/not/exist' is not a directory.");
   }
 
   @Test


### PR DESCRIPTION
Add a DataEntityManager that writes to files in a directory. Only use
the ZIP file DataEntityManager when the output path ends in '.zip'.

Change-Id: If4bf6bd3332bc6485cfae36aefc58e9b3389cb53