### PR TITLE
Add AllTempTablesVX data into the extraction output.

### DIFF
--- a/src/java/com/google/cloud/bigquery/dwhassessment/extractiontool/dbscripts/InternalScriptLoader.java
+++ b/src/java/com/google/cloud/bigquery/dwhassessment/extractiontool/dbscripts/InternalScriptLoader.java
@@ -43,6 +43,7 @@ public class InternalScriptLoader implements ScriptLoader {
             "roles",
             "tableinfo",
             "tablesize",
+            "temp_tables",
             "users")
         .stream()
         .collect(

--- a/src/java/com/google/cloud/bigquery/dwhassessment/extractiontool/dbscripts/temp_tables.sql
+++ b/src/java/com/google/cloud/bigquery/dwhassessment/extractiontool/dbscripts/temp_tables.sql
@@ -1,0 +1,22 @@
+-- Copyright 2021 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     https://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+SELECT
+  HostNo AS "HostNo",
+  SessionNo AS "SessionNo",
+  UserName AS "UserName",
+  B_DatabaseName AS "B_DatabaseName",
+  B_TableName AS "B_TableName",
+  E_TableId AS "E_TableId"
+FROM DBC.AllTempTablesVX;

--- a/src/javatests/com/google/cloud/bigquery/dwhassessment/extractiontool/dbscripts/InternalScriptLoaderTest.java
+++ b/src/javatests/com/google/cloud/bigquery/dwhassessment/extractiontool/dbscripts/InternalScriptLoaderTest.java
@@ -563,6 +563,32 @@ public class InternalScriptLoaderTest {
         .containsExactly(expectedRecord1, expectedRecord2);
   }
 
+  @Test
+  public void loadScripts_temptables() throws IOException, SQLException {
+    String scriptName = "temptables";
+    String sqlScript = scriptManager.getScript(scriptName);
+    // Get schema and verify records.
+    Schema schema = scriptRunner.extractSchema(connection, sqlScript, scriptName, "namespace");
+    ImmutableList<GenericRecord> records =
+        scriptRunner.executeScriptToAvro(connection, /*sqlScript=*/ sqlScript, schema);
+    GenericRecord expectedRecord =
+        new GenericRecordBuilder(schema)
+            .set("HostNo", 1)
+            .set("SessionNo", 1)
+            .set("UserName", "user_name")
+            .set("B_DatabaseName", "database_name")
+            .set("B_TableName", "table_name")
+            .set("E_TableId", ByteBuffer.wrap(new byte[] {1, 2, 3, 4, 5, 6}))
+            .build();
+    assertThat(records).containsExactly(expectedRecord);
+
+    // Verify records serialization.
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    scriptManager.executeScript(connection, scriptName, new DataEntityManagerTesting(outputStream));
+    assertThat(readOutputStreamToAvro(outputStream, 1))
+        .containsExactly(expectedRecord);
+  }
+
   private ImmutableList<Record> readOutputStreamToAvro(
       ByteArrayOutputStream outputStream, int recordNum) throws IOException {
     DataFileReader<Record> reader = getAvroDataOutputReader(outputStream);

--- a/src/javatests/com/google/cloud/bigquery/dwhassessment/extractiontool/dbscripts/test_data.sql
+++ b/src/javatests/com/google/cloud/bigquery/dwhassessment/extractiontool/dbscripts/test_data.sql
@@ -12,6 +12,23 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
+INSERT INTO DBC.AllTempTablesVX (
+  HostNo,
+  SessionNo,
+  UserName,
+  B_DatabaseName,
+  B_TableName,
+  E_TableId
+)
+VALUES(
+  1,
+  1,
+  'user_name',
+  'database_name',
+  'table_name',
+   X'010203040506'
+);
+
 INSERT INTO DBC.DiskSpaceV (
   VProc,
   DatabaseName,

--- a/src/javatests/com/google/cloud/bigquery/dwhassessment/extractiontool/faketd/teradata_tables.sql
+++ b/src/javatests/com/google/cloud/bigquery/dwhassessment/extractiontool/faketd/teradata_tables.sql
@@ -14,6 +14,15 @@
 
 CREATE SCHEMA DBC;
 
+CREATE TABLE DBC.AllTempTablesVX (
+  HostNo SMALLINT,
+  SessionNo INT,
+  UserName VARCHAR(128),
+  B_DatabaseName VARCHAR(128),
+  B_TableName VARCHAR(128),
+  E_TableId BINARY(6)
+);
+
 CREATE TABLE DBC.TablesV (
   DatabaseName VARCHAR(128),
   TableName VARCHAR(128),


### PR DESCRIPTION
Tested by connecting to an actual TD instance with new test data about temp tables in the database.