### PR TITLE
Fix InternalScriptLoaderTest's call to getScript

### DIFF
--- a/src/javatests/com/google/cloud/bigquery/dwhassessment/extractiontool/dbscripts/InternalScriptLoaderTest.java
+++ b/src/javatests/com/google/cloud/bigquery/dwhassessment/extractiontool/dbscripts/InternalScriptLoaderTest.java
@@ -265,7 +265,7 @@ public class InternalScriptLoaderTest {
   @Test
   public void loadScripts_stats() throws SQLException, IOException {
     String scriptName = "stats";
-    String sqlScript = scriptManager.getScript(scriptName);
+    String sqlScript = getScript(scriptName);
     Schema schema = scriptRunner.extractSchema(connection, sqlScript, scriptName, "namespace");
 
     ImmutableList<GenericRecord> records =


### PR DESCRIPTION
The test had two concorruent changes which lead to a compile error.
The fix is to apply the samge change on how to get a script to
the newly added test.

Change-Id: I7e603d02c3aba6d05a99485cb8b89db231824264