### PR TITLE
Add UpperCaseFlag to columnsV for case-sensitivity.

### DIFF
--- a/src/java/com/google/cloud/bigquery/dwhassessment/extractiontool/dbscripts/columns.sql
+++ b/src/java/com/google/cloud/bigquery/dwhassessment/extractiontool/dbscripts/columns.sql
@@ -23,7 +23,8 @@ SELECT
   "ColumnsV"."DefaultValue",
   "ColumnsV"."ColumnConstraint",
   "ColumnsV"."ConstraintCount",
-  "ColumnsV"."Nullable"
+  "ColumnsV"."Nullable",
+  "ColumnsV"."UpperCaseFlag"
 FROM "{{baseDatabase}}"."TablesV"
 INNER JOIN "{{baseDatabase}}"."ColumnsV" ON "TablesV"."DatabaseName" = "ColumnsV"."DatabaseName"
         AND "TablesV"."TableName" = "ColumnsV"."TableName"

--- a/src/javatests/com/google/cloud/bigquery/dwhassessment/extractiontool/dbscripts/InternalScriptLoaderTest.java
+++ b/src/javatests/com/google/cloud/bigquery/dwhassessment/extractiontool/dbscripts/InternalScriptLoaderTest.java
@@ -418,6 +418,7 @@ public class InternalScriptLoaderTest {
             .set("ColumnConstraint", "test constraint")
             .set("ConstraintCount", 1)
             .set("Nullable", "Y")
+            .set("UpperCaseFlag", "U")
             .build();
     assertThat(records).containsExactly(expectedRecord);
 

--- a/src/javatests/com/google/cloud/bigquery/dwhassessment/extractiontool/dbscripts/test_data.sql
+++ b/src/javatests/com/google/cloud/bigquery/dwhassessment/extractiontool/dbscripts/test_data.sql
@@ -294,7 +294,8 @@ INSERT INTO DBC."ColumnsV" (
   "DefaultValue",
   "ColumnConstraint",
   "ConstraintCount",
-  "Nullable"
+  "Nullable",
+  "UpperCaseFlag"
 )
 VALUES (
   'test_database',
@@ -307,7 +308,8 @@ VALUES (
   '0',
   'test constraint',
   1,
-  'Y'
+  'Y',
+  'U'
 ), (
    'test_database',
    'not_existing_table',
@@ -319,7 +321,8 @@ VALUES (
    '0',
    'test constraint',
    1,
-   'N'
+   'N',
+   'C'
 );
 
 INSERT INTO DBC."DatabasesV" (

--- a/src/javatests/com/google/cloud/bigquery/dwhassessment/extractiontool/faketd/teradata_tables.sql
+++ b/src/javatests/com/google/cloud/bigquery/dwhassessment/extractiontool/faketd/teradata_tables.sql
@@ -60,6 +60,7 @@ CREATE TABLE DBC."ColumnsV" (
   "ColumnConstraint" VARCHAR(8192),
   "ConstraintCount" SMALLINT,
   "Nullable" CHAR(1),
+  "UpperCaseFlag" CHAR(1),
   PRIMARY KEY ("DatabaseName", "TableName", "ColumnName")
 );
 


### PR DESCRIPTION
Case sensitivity is determined by UpperCaseFlag column from ColumnsV
table and TxnMode from QryLogV. The determination will be done in
the assessment component.