### PR TITLE
Use JDK14 log binding instead of log4j

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -30,7 +30,7 @@ maven_install(
         "org.hsqldb:hsqldb:2.6.0",
         "org.hsqldb:sqltool:2.6.0",
         "org.mockito:mockito-core:3.11.1",
-        "org.slf4j:slf4j-log4j12:1.7.32",
+        "org.slf4j:slf4j-jdk14:1.7.32",
     ],
     fetch_sources = True,
     repositories = [

--- a/src/java/com/google/cloud/bigquery/dwhassessment/extractiontool/BUILD
+++ b/src/java/com/google/cloud/bigquery/dwhassessment/extractiontool/BUILD
@@ -32,7 +32,7 @@ java_binary(
     main_class = "com.google.cloud.bigquery.dwhassessment.extractiontool.ExtractionTool",
     runtime_deps = [
         ":extraction_tool",
-        "@maven//:org_slf4j_slf4j_log4j12",
+        "@maven//:org_slf4j_slf4j_jdk14",
     ],
 )
 
@@ -42,6 +42,6 @@ java_binary(
     runtime_deps = [
         ":extraction_tool",
         "@maven//:org_hsqldb_hsqldb",
-        "@maven//:org_slf4j_slf4j_log4j12",
+        "@maven//:org_slf4j_slf4j_jdk14",
     ],
 )


### PR DESCRIPTION
There is a severe RCE vulnaribility in log4j. This tool should not have any
security issues from this since it only deals with trusted data but given that
there will be widespread attacks it might eventually blead through.

Change-Id: I2bd230eb504cafe4270c816f508828b724048471