### PR TITLE
Moving test data generation to a dedicated class

### DIFF
--- a/integ-tests/pom.xml
+++ b/integ-tests/pom.xml
@@ -86,6 +86,37 @@
                     <argLine>-Djava.util.logging.config.file=src/main/resources/logging.properties</argLine>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.0.0</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>java</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <includePluginDependencies>true</includePluginDependencies>
+                    <mainClass>com.google.testdata.TestDataGenerator</mainClass>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.teradata.jdbc</groupId>
+                        <artifactId>terajdbc4</artifactId>
+                        <version>16.20</version>
+                        <scope>system</scope>
+                        <systemPath>${env.JDBC_PATH}</systemPath>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-jdk14</artifactId>
+                        <version>2.0.0-alpha5</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/integ-tests/src/main/java/com/google/testdata/TestDataGenerator.java
+++ b/integ-tests/src/main/java/com/google/testdata/TestDataGenerator.java
@@ -1,0 +1,17 @@
+package com.google.testdata;
+
+import com.google.base.TestBase;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+
+/** Test data generation class */
+public class TestDataGenerator extends TestBase {
+
+  public static void main(String[] args) throws SQLException {
+    Connection connection = DriverManager.getConnection(URL_DB, USERNAME_DB, PASSWORD_DB);
+
+    // Generate test data for users.sql
+    TestDataHelper.generateUsers(connection, 10);
+  }
+}

--- a/integ-tests/src/main/java/com/google/testdata/TestDataHelper.java
+++ b/integ-tests/src/main/java/com/google/testdata/TestDataHelper.java
@@ -3,15 +3,21 @@ package com.google.testdata;
 import static java.lang.String.format;
 import static java.lang.System.nanoTime;
 
+import com.google.base.TestBase;
+import com.google.common.base.Joiner;
 import com.google.sql.SqlHelper;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Helper class providing test data generation methods */
 public final class TestDataHelper {
+
+  private static final Logger logger = LoggerFactory.getLogger(TestBase.class);
 
   private TestDataHelper() {}
 
@@ -27,5 +33,7 @@ public final class TestDataHelper {
     sqlQueries =
         sqlQueries.stream().map(e -> e = format(e, nanoTime())).collect(Collectors.toList());
     SqlHelper.executeQueries(connection, sqlQueries);
+    logger.info(
+        format("Generated %s new Users:\n%s", sqlQueries.size(), Joiner.on("\n").join(sqlQueries)));
   }
 }

--- a/integ-tests/src/test/java/com/google/integration/IntegrationTests.java
+++ b/integ-tests/src/test/java/com/google/integration/IntegrationTests.java
@@ -23,7 +23,6 @@ import com.google.base.TestBase;
 import com.google.pojo.UserTableRow;
 import com.google.sql.SqlHelper;
 import com.google.tdjdbc.JdbcHelper;
-import com.google.testdata.TestDataHelper;
 import java.io.IOException;
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -53,8 +52,6 @@ public class IntegrationTests extends TestBase {
 
     List<UserTableRow> dbList = new ArrayList<>();
     List<UserTableRow> avroList = new ArrayList<>();
-
-    TestDataHelper.generateUsers(connection, 10);
 
     try (PreparedStatement preparedStatement =
         connection.prepareStatement(format(SqlHelper.getSql(sqlPath), DB_NAME))) {


### PR DESCRIPTION
Moving test data generation to a dedicated class

1. Test data generation can be called separately from tests
2. Configured exec-maven-plugin for running TestDataGenerator.java