### PR TITLE
Add querylogs_full.sql to extract non-truncated logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.sw[a-z]
 bazel-*
+
+.ijwb

--- a/src/java/com/google/cloud/bigquery/dwhassessment/extractiontool/db/SqlScriptVariables.java
+++ b/src/java/com/google/cloud/bigquery/dwhassessment/extractiontool/db/SqlScriptVariables.java
@@ -54,13 +54,13 @@ public abstract class SqlScriptVariables {
 
     @AutoValue
     public abstract static class TimeRange {
-      private static final String min_time = "0001-01-01 00:00:00";
-      private static final String max_time = "9999-12-31 23:59:59.99";
+      private static final String minTime = "0001-01-01 00:00:00";
+      private static final String maxTime = "9999-12-31 23:59:59.99";
 
       public static Builder builder() {
         return new AutoValue_SqlScriptVariables_QueryLogsVariables_TimeRange.Builder()
-            .setStartTimestamp(min_time)
-            .setEndTimestamp(max_time);
+            .setStartTimestamp(minTime)
+            .setEndTimestamp(maxTime);
       }
 
       public abstract String getStartTimestamp();

--- a/src/java/com/google/cloud/bigquery/dwhassessment/extractiontool/dbscripts/InternalScriptLoader.java
+++ b/src/java/com/google/cloud/bigquery/dwhassessment/extractiontool/dbscripts/InternalScriptLoader.java
@@ -41,6 +41,7 @@ public class InternalScriptLoader implements ScriptLoader {
             "partitioning_constraints",
             "query_references",
             "querylogs",
+            "querylogs_full",
             "roles",
             "stats",
             "tableinfo",

--- a/src/java/com/google/cloud/bigquery/dwhassessment/extractiontool/dbscripts/querylogs_full.sql
+++ b/src/java/com/google/cloud/bigquery/dwhassessment/extractiontool/dbscripts/querylogs_full.sql
@@ -14,7 +14,7 @@
 
 -- This SQL extracts all non-truncated SQL statements from DBC.QryLogSQLV by default
 SELECT
-  {{#if vars.columnNameRowNumber}}"{{vars.columnNameRowNumber}}"{{else}}"SqlRowNo"{{/if}} AS "SqlRowNo",
-  {{#if vars.columnNameQueryID}}"{{vars.columnNameQueryID}}"{{else}}"QueryID"{{/if}} AS "QueryID",
-  {{#if vars.columnNameQueryText}}"{{vars.columnNameQueryText}}"{{else}}"SqlTextInfo"{{/if}} AS "QueryText"
+  "{{#if vars.columnNameRowNumber}}{{vars.columnNameRowNumber}}{{else}}SqlRowNo{{/if}}" AS "SqlRowNo",
+  "{{#if vars.columnNameQueryID}}{{vars.columnNameQueryID}}{{else}}QueryID{{/if}}" AS "QueryID",
+  "{{#if vars.columnNameQueryText}}{{vars.columnNameQueryText}}{{else}}SqlTextInfo{{/if}}" AS "QueryText"
 FROM "{{baseDatabase}}"."{{#if vars.tableName}}{{vars.tableName}}{{else}}QryLogSQLV{{/if}}"

--- a/src/java/com/google/cloud/bigquery/dwhassessment/extractiontool/dbscripts/querylogs_full.sql
+++ b/src/java/com/google/cloud/bigquery/dwhassessment/extractiontool/dbscripts/querylogs_full.sql
@@ -1,0 +1,20 @@
+-- Copyright 2021 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     https://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- This SQL extracts all non-truncated SQL statements from DBC.QryLogSQLV by default
+SELECT
+  {{#if vars.columnNameRowNumber}}"{{vars.columnNameRowNumber}}"{{else}}"SqlRowNo"{{/if}} AS "SqlRowNo",
+  {{#if vars.columnNameQueryID}}"{{vars.columnNameQueryID}}"{{else}}"QueryID"{{/if}} AS "QueryID",
+  {{#if vars.columnNameQueryText}}"{{vars.columnNameQueryText}}"{{else}}"SqlTextInfo"{{/if}} AS "QueryText"
+FROM "{{baseDatabase}}"."{{#if vars.tableName}}{{vars.tableName}}{{else}}QryLogSQLV{{/if}}"


### PR DESCRIPTION
In addition to `QryLogV`, where QueryText is truncated at length of 200, we extract full SQL queries from `QryLogSQLV` (large queries are being split to multiple rows with the same QueryID by SqlRowNo)

SQL script supports different DB, view, and column names via parameters:
```bash
--script-vars querylogs_full.tableName=TableNameOverride
--script-vars querylogs_full.columnNameRowNumber=RowNumberColumnOverride
--script-base-db querylogs_full=DBNameOverride
```