### PR TITLE
Change query_references.sql to use QryLogObjectsV instead of DBQLObjTbl

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,16 +20,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 ## Extraction tool user guide
-The extraction tool is currently intended for approved users that are engaging 
+The extraction tool is currently intended for approved users that are engaging
 with GCP technical sales teams.
 
-**Step 1:** Follow the user guide from the GCP technical sales team and download 
+**Step 1:** Follow the user guide from the GCP technical sales team and download
 the Extraction tool binary (i.e., ExtractionTool_deploy.jar) and its run script.
 
 **Step 2:** Download [Teradata JDBC driver](https://downloads.teradata.com/download/connectivity/jdbc-driver) into the same directory with the Extraction tool binary.
 
 **Step 3:** Create a folder for output files and run the Extraction tool:
-```build
+```bash
 ./run-td-extract.sh -j <terajdbc4.jar> --db-address <database address> --output <output path> --db-user <db user>
 ```
 
@@ -41,18 +41,25 @@ the Extraction tool binary (i.e., ExtractionTool_deploy.jar) and its run script.
 - Multiple filters can be defined by repeating the option. Each filter has to match (i.e. AND logic).
 
 `--sql-scripts`  The list of scripts to execute. By default, all available scripts will be executed.
-- Available scripts extract metadata from tables:
-    - [All_RI_ChildrenV](https://docs.teradata.com/r/oiS9ixs2ypIQvjTUOJfgoA/CDg3b4d71cfITbRjAAQM5Q)
-    - [All_RI_ParentsV](https://docs.teradata.com/r/oiS9ixs2ypIQvjTUOJfgoA/KjM9MSv3K5G5Q_gCTNtGZw)
-    - [ColumnsV](https://docs.teradata.com/r/oiS9ixs2ypIQvjTUOJfgoA/fQ8NslP6DDESV0ZiODLlIw)
-    - [DiskSpaceV](https://docs.teradata.com/r/oiS9ixs2ypIQvjTUOJfgoA/ZhJCNhtQ1i4llpxKkYn7eA)
-    - [FunctionsV](https://docs.teradata.com/r/oiS9ixs2ypIQvjTUOJfgoA/hx9hvPb9EvS6TP9Ta2PUzQ)
-    - [IndicesV](https://docs.teradata.com/r/oiS9ixs2ypIQvjTUOJfgoA/qkWdqMUH7HZaIkY_pSQUng)
-    - [QryLog](https://docs.teradata.com/r/oiS9ixs2ypIQvjTUOJfgoA/sT8ifzajeQ9jMx7ciiu1dA)
-    - [TablesV](https://docs.teradata.com/r/oiS9ixs2ypIQvjTUOJfgoA/JKGDTOsfv6_gr8wswcE9eA)
-    - [TableSizeV](https://docs.teradata.com/r/oiS9ixs2ypIQvjTUOJfgoA/qQd_5O6fT0QrDcSfDEZj~Q)
-    - [UsersV](https://docs.teradata.com/r/oiS9ixs2ypIQvjTUOJfgoA/rES2eYXMN2IBoFBIPIWz0Q)
-- [Click to view the scripts.](https://team.git.corp.google.com/edwmigration-eng/dwh-assessment-extraction-tool/+/refs/heads/master/src/java/com/google/cloud/bigquery/dwhassessment/extractiontool/dbscripts/)
+- Available scripts extract metadata from tables and views:
+  - [AllTempTablesVX](https://docs.teradata.com/r/oiS9ixs2ypIQvjTUOJfgoA/FVKCCZtalFF_UOT2PcPfrA)
+  - [All_RI_ChildrenV](https://docs.teradata.com/r/oiS9ixs2ypIQvjTUOJfgoA/CDg3b4d71cfITbRjAAQM5Q)
+  - [All_RI_ParentsV](https://docs.teradata.com/r/oiS9ixs2ypIQvjTUOJfgoA/KjM9MSv3K5G5Q_gCTNtGZw)
+  - [ColumnsV](https://docs.teradata.com/r/oiS9ixs2ypIQvjTUOJfgoA/fQ8NslP6DDESV0ZiODLlIw)
+  - [DatabasesV](https://docs.teradata.com/r/oiS9ixs2ypIQvjTUOJfgoA/GqTx8VuBIkfaC4fso9f5cw)
+  - [DiskSpaceV](https://docs.teradata.com/r/oiS9ixs2ypIQvjTUOJfgoA/ZhJCNhtQ1i4llpxKkYn7eA)
+  - [FunctionsV](https://docs.teradata.com/r/oiS9ixs2ypIQvjTUOJfgoA/hx9hvPb9EvS6TP9Ta2PUzQ)
+  - [IndicesV](https://docs.teradata.com/r/oiS9ixs2ypIQvjTUOJfgoA/qkWdqMUH7HZaIkY_pSQUng)
+  - [PartitioningConstraintsV](https://docs.teradata.com/r/oiS9ixs2ypIQvjTUOJfgoA/G5eOtdk_Z5xjAgAderQlQg)
+  - [QryLogObjectsV](https://docs.teradata.com/r/oiS9ixs2ypIQvjTUOJfgoA/FvQHxfqfQIWCkPhL9vlYvw)
+  - [QryLogV](https://docs.teradata.com/r/oiS9ixs2ypIQvjTUOJfgoA/sT8ifzajeQ9jMx7ciiu1dA)
+  - [QryLogSQLV](https://docs.teradata.com/r/oiS9ixs2ypIQvjTUOJfgoA/SQqDiRkDlOLYNSZ4dBRIGQ)
+  - [RoleMembersV](https://docs.teradata.com/r/oiS9ixs2ypIQvjTUOJfgoA/y5EHNeWIu1uFk5714KHTaw)
+  - [StatsV](https://docs.teradata.com/r/oiS9ixs2ypIQvjTUOJfgoA/nLsDT6mdwnn1QrOG35ttMw)
+  - [TablesV](https://docs.teradata.com/r/oiS9ixs2ypIQvjTUOJfgoA/JKGDTOsfv6_gr8wswcE9eA)
+  - [TableSizeV](https://docs.teradata.com/r/oiS9ixs2ypIQvjTUOJfgoA/qQd_5O6fT0QrDcSfDEZj~Q)
+  - [UsersV](https://docs.teradata.com/r/oiS9ixs2ypIQvjTUOJfgoA/rES2eYXMN2IBoFBIPIWz0Q)
+- [Click to view the scripts.](src/java/com/google/cloud/bigquery/dwhassessment/extractiontool/dbscripts)
 
 `--skip-sql-scripts` The list of scripts to skip. By default, all available scripts will be executed.
 

--- a/src/java/com/google/cloud/bigquery/dwhassessment/extractiontool/dbscripts/query_references.sql
+++ b/src/java/com/google/cloud/bigquery/dwhassessment/extractiontool/dbscripts/query_references.sql
@@ -24,8 +24,8 @@ SELECT
   "ObjectType",
   "FreqofUse",
   "TypeofUse"
-FROM "{{baseDatabase}}"."{{#if vars.tableName}}{{vars.tableName}}{{else}}DBQLObjTbl{{/if}}"
+FROM "{{baseDatabase}}"."{{#if vars.tableName}}{{vars.tableName}}{{else}}QryLogObjectsV{{/if}}"
 {{#if queryLogsVariables.timeRange}}
-WHERE "{{baseDatabase}}"."{{#if vars.tableName}}{{vars.tableName}}{{else}}DBQLObjTbl{{/if}}"."CollectTimeStamp"
+WHERE "{{baseDatabase}}"."{{#if vars.tableName}}{{vars.tableName}}{{else}}QryLogObjectsV{{/if}}"."CollectTimeStamp"
   BETWEEN TIMESTAMP '{{queryLogsVariables.timeRange.startTimestamp}}' AND TIMESTAMP '{{queryLogsVariables.timeRange.endTimestamp}}'
 {{/if}}

--- a/src/javatests/com/google/cloud/bigquery/dwhassessment/extractiontool/dbscripts/test_data.sql
+++ b/src/javatests/com/google/cloud/bigquery/dwhassessment/extractiontool/dbscripts/test_data.sql
@@ -641,7 +641,7 @@ VALUES (
   0
 );
 
-INSERT INTO DBC."DBQLObjTbl" (
+INSERT INTO DBC."QryLogObjectsV" (
   "ProcID",
   "CollectTimeStamp",
   "QueryID",

--- a/src/javatests/com/google/cloud/bigquery/dwhassessment/extractiontool/faketd/teradata_tables.sql
+++ b/src/javatests/com/google/cloud/bigquery/dwhassessment/extractiontool/faketd/teradata_tables.sql
@@ -342,7 +342,7 @@ CREATE TABLE DBC."PartitioningConstraintsV" (
   "ColumnPartitioningLevel" SMALLINT NOT NULL,
 );
 
-CREATE TABLE DBC."DBQLObjTbl" (
+CREATE TABLE DBC."QryLogObjectsV" (
   "ProcID" DECIMAL(5,0) NOT NULL,
   "CollectTimeStamp" TIMESTAMP(6) NOT NULL,
   "QueryID" DECIMAL(18,0) NOT NULL,


### PR DESCRIPTION
Update README.md to list all views and tables used during extraction

Tested on local stack – number of rows from DBQLObjTbl and QryLogObjectsV is the same