### PR TITLE
Fix picocli.CommandLineInitializationException

### DIFF
--- a/src/java/com/google/cloud/bigquery/dwhassessment/extractiontool/dbscripts/InternalScriptLoader.java
+++ b/src/java/com/google/cloud/bigquery/dwhassessment/extractiontool/dbscripts/InternalScriptLoader.java
@@ -61,7 +61,7 @@ public class InternalScriptLoader implements ScriptLoader {
   @Override
   public ImmutableMap<String, ImmutableList<String>> getSortingColumnsMap() {
     return new ImmutableMap.Builder<String, ImmutableList<String>>()
-        .put("querylogs.sql", ImmutableList.of("\"StartTime\""))
+        .put("querylogs", ImmutableList.of("StartTime"))
         .build();
   }
 

--- a/src/java/com/google/cloud/bigquery/dwhassessment/extractiontool/dbscripts/querylogs.sql
+++ b/src/java/com/google/cloud/bigquery/dwhassessment/extractiontool/dbscripts/querylogs.sql
@@ -147,5 +147,5 @@ WHERE "{{baseDatabase}}"."{{#if vars.tableName}}{{vars.tableName}}{{else}}QryLog
   BETWEEN TIMESTAMP '{{queryLogsVariables.timeRange.startTimestamp}}' AND TIMESTAMP '{{queryLogsVariables.timeRange.endTimestamp}}'
 {{/if}}
 {{#if sortingColumns}}
-ORDER BY {{#each sortingColumns}}{{this}}{{#unless @last}},{{/unless}}{{/each}} ASC NULLS FIRST
+ORDER BY {{#each sortingColumns}}"{{this}}"{{#unless @last}},{{/unless}}{{/each}} ASC NULLS FIRST
 {{/if}}

--- a/src/java/com/google/cloud/bigquery/dwhassessment/extractiontool/subcommand/ExtractSubcommand.java
+++ b/src/java/com/google/cloud/bigquery/dwhassessment/extractiontool/subcommand/ExtractSubcommand.java
@@ -100,14 +100,14 @@ public final class ExtractSubcommand implements Callable<Integer> {
   private String dbAddress;
 
   @Option(names = "--db-user", description = "The user name for the database.")
-  private final String dbUserName = "";
+  private String dbUserName = "";
 
   @Option(
       names = "--db-password",
       description = "The password for the database.",
       arity = "0..1",
       interactive = true)
-  private final String dbPassword = "";
+  private String dbPassword = "";
 
   @Option(
       names = "--base-db",

--- a/src/javatests/com/google/cloud/bigquery/dwhassessment/extractiontool/subcommand/ExtractSubcommandTest.java
+++ b/src/javatests/com/google/cloud/bigquery/dwhassessment/extractiontool/subcommand/ExtractSubcommandTest.java
@@ -83,6 +83,34 @@ public final class ExtractSubcommandTest {
   }
 
   @Test
+  public void call_db_user_and_db_password_success() throws IOException, SQLException {
+    ExtractExecutor executor = Mockito.mock(ExtractExecutor.class);
+    CommandLine cmd = new CommandLine(new ExtractSubcommand(() -> executor, scriptManager));
+
+    assertThat(
+        cmd.execute(
+            "--db-address",
+            "jdbc:hsqldb:mem:my-animalclinic.example",
+            "--db-user",
+            "dbc",
+            "--db-password",
+            "dbc",
+            "--output",
+            outputPath.toString()))
+        .isEqualTo(0);
+
+    ArgumentCaptor<ExtractExecutor.Arguments> argumentsCaptor =
+        ArgumentCaptor.forClass(ExtractExecutor.Arguments.class);
+    verify(executor).run(argumentsCaptor.capture());
+    ExtractExecutor.Arguments arguments = argumentsCaptor.getValue();
+
+    assertThat(arguments.outputPath().toString()).isEqualTo(outputPath.toString());
+    assertThat(arguments.sqlScripts()).isEmpty();
+    assertThat(arguments.skipSqlScripts()).isEmpty();
+    assertThat(arguments.chunkRows()).isEqualTo(0);
+  }
+
+  @Test
   public void call_successWithChunkRows() throws IOException, SQLException {
     ExtractExecutor executor = Mockito.mock(ExtractExecutor.class);
     CommandLine cmd = new CommandLine(new ExtractSubcommand(() -> executor, scriptManager));


### PR DESCRIPTION
Flags can not be final.

Also, fixed getSortingColumnsMap – script name should be without extension, and sorting columns should be without quotes