### PR TITLE
Fix wrong datetime pattern for qrylog-time flags

### DIFF
--- a/src/java/com/google/cloud/bigquery/dwhassessment/extractiontool/executor/ExtractExecutorImpl.java
+++ b/src/java/com/google/cloud/bigquery/dwhassessment/extractiontool/executor/ExtractExecutorImpl.java
@@ -55,7 +55,7 @@ import org.apache.avro.generic.GenericRecord;
 public final class ExtractExecutorImpl implements ExtractExecutor {
 
   private static final DateTimeFormatter TERADATA_TIME_FORMATTER =
-      DateTimeFormatter.ofPattern("yyyy-MM-dd kk:mm:ss[.SSSSSS]").withZone(ZoneOffset.UTC);
+      DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss[.SSSSSS]").withZone(ZoneOffset.UTC);
 
   private static final Logger LOGGER = Logger.getLogger(ExtractExecutorImpl.class.getName());
 

--- a/src/javatests/com/google/cloud/bigquery/dwhassessment/extractiontool/executor/ExtractExecutorImplTest.java
+++ b/src/javatests/com/google/cloud/bigquery/dwhassessment/extractiontool/executor/ExtractExecutorImplTest.java
@@ -310,4 +310,12 @@ public final class ExtractExecutorImplTest {
     assertThat(getTeradataTimestampFromInstant(Instant.parse("2022-01-24T14:52:00.123456Z")))
         .isEqualTo("2022-01-24 14:52:00.123456");
   }
+
+  @Test
+  public void getTeradataTimestampFromInstant_timeBoundaries() {
+    assertThat(getTeradataTimestampFromInstant(Instant.parse("2022-10-01T00:00:00Z")))
+        .isEqualTo("2022-10-01 00:00:00.000000");
+    assertThat(getTeradataTimestampFromInstant(Instant.parse("2022-10-01T24:00:00Z")))
+        .isEqualTo("2022-10-02 00:00:00.000000");
+  }
 }


### PR DESCRIPTION
Using kk (clock-hour-of-am-pm, range 00-24) instead of HH (hour-of-day, range 00-23) leads to dates passed to qrylog-time flags be incorrectly transformed in SQL scripts.

For example, 2021-10-01 is transformed as 2021-10-01 24:00:00.000000 in the SQL script.