### PR TITLE
Make db-user a required flag because it doesn't make sense to access a data warehouse without a username.

### DIFF
--- a/src/java/com/google/cloud/bigquery/dwhassessment/extractiontool/subcommand/ExtractSubcommand.java
+++ b/src/java/com/google/cloud/bigquery/dwhassessment/extractiontool/subcommand/ExtractSubcommand.java
@@ -99,15 +99,16 @@ public final class ExtractSubcommand implements Callable<Integer> {
       })
   private String dbAddress;
 
-  @Option(names = "--db-user", description = "The user name for the database.")
-  private String dbUserName = "";
+  @Option(names = "--db-user", required = true, description = "The user name for the database.")
+  private String dbUserName;
 
   @Option(
       names = "--db-password",
       description = "The password for the database.",
+      required = true,
       arity = "0..1",
       interactive = true)
-  private String dbPassword = "";
+  private String dbPassword;
 
   @Option(
       names = "--base-db",

--- a/src/javatests/com/google/cloud/bigquery/dwhassessment/extractiontool/subcommand/ExtractSubcommandTest.java
+++ b/src/javatests/com/google/cloud/bigquery/dwhassessment/extractiontool/subcommand/ExtractSubcommandTest.java
@@ -66,7 +66,7 @@ public final class ExtractSubcommandTest {
     assertThat(
             cmd.execute(
                 "--db-address",
-                "jdbc:hsqldb:mem:my-animalclinic.example",
+                "jdbc:hsqldb:mem:my-db1.example",
                 "--output",
                 outputPath.toString()))
         .isEqualTo(0);
@@ -90,7 +90,7 @@ public final class ExtractSubcommandTest {
     assertThat(
         cmd.execute(
             "--db-address",
-            "jdbc:hsqldb:mem:my-animalclinic.example",
+            "jdbc:hsqldb:mem:shiny-brand-new-db",
             "--db-user",
             "dbc",
             "--db-password",
@@ -118,7 +118,7 @@ public final class ExtractSubcommandTest {
     assertThat(
             cmd.execute(
                 "--db-address",
-                "jdbc:hsqldb:mem:my-animalclinic.example",
+                "jdbc:hsqldb:mem:my-db2.example",
                 "--output",
                 outputPath.toString(),
                 "--rows-per-chunk",
@@ -144,7 +144,7 @@ public final class ExtractSubcommandTest {
     assertThat(
             cmd.execute(
                 "--db-address",
-                "jdbc:hsqldb:mem:my-animalclinic.example",
+                "jdbc:hsqldb:mem:my-db3.example",
                 "--output",
                 outputPath.toString(),
                 "--sql-scripts",
@@ -170,7 +170,7 @@ public final class ExtractSubcommandTest {
     assertThat(
             cmd.execute(
                 "--db-address",
-                "jdbc:hsqldb:mem:my-animalclinic.example",
+                "jdbc:hsqldb:mem:my-db4.example",
                 "--output",
                 outputPath.toString(),
                 "--skip-sql-scripts",
@@ -198,7 +198,7 @@ public final class ExtractSubcommandTest {
     assertThat(
             cmd.execute(
                 "--db-address",
-                "jdbc:hsqldb:mem:my-animalclinic.example",
+                "jdbc:hsqldb:mem:my-db5.example",
                 "--output",
                 outputPath.toString(),
                 "--schema-filter",
@@ -226,7 +226,7 @@ public final class ExtractSubcommandTest {
     assertThat(
             cmd.execute(
                 "--db-address",
-                "jdbc:hsqldb:mem:my-animalclinic.example",
+                "jdbc:hsqldb:mem:my-db6.example",
                 "--output",
                 outputPath.toString(),
                 "--qrylog-timerange-start",
@@ -254,7 +254,7 @@ public final class ExtractSubcommandTest {
     assertThat(
             cmd.execute(
                 "--db-address",
-                "jdbc:hsqldb:mem:my-animalclinic.example",
+                "jdbc:hsqldb:mem:my-db7.example",
                 "--output",
                 outputPath.toString(),
                 "--qrylog-timerange-start",
@@ -281,7 +281,7 @@ public final class ExtractSubcommandTest {
     assertThat(
             cmd.execute(
                 "--db-address",
-                "jdbc:hsqldb:mem:my-animalclinic.example",
+                "jdbc:hsqldb:mem:my-db8.example",
                 "--output",
                 outputPath.toString(),
                 "--qrylog-timerange-end",
@@ -311,7 +311,7 @@ public final class ExtractSubcommandTest {
     assertThat(
             cmd.execute(
                 "--db-address",
-                "jdbc:hsqldb:mem:my-animalclinic.example",
+                "jdbc:hsqldb:mem:my-db9.example",
                 "--output",
                 outputPath.toString(),
                 "--qrylog-timerange-start",
@@ -344,7 +344,7 @@ public final class ExtractSubcommandTest {
     assertThat(
             cmd.execute(
                 "--db-address",
-                "jdbc:hsqldb:mem:my-animalclinic.example",
+                "jdbc:hsqldb:mem:my-db10.example",
                 "--output",
                 outputPath.toString(),
                 "--qrylog-timerange-start",
@@ -376,7 +376,7 @@ public final class ExtractSubcommandTest {
     assertThat(
             cmd.execute(
                 "--db-address",
-                "jdbc:hsqldb:mem:my-animalclinic.example",
+                "jdbc:hsqldb:mem:my-db11.example",
                 "--output",
                 outputPath.toString(),
                 "--script-base-db",
@@ -401,7 +401,7 @@ public final class ExtractSubcommandTest {
     assertThat(
             cmd.execute(
                 "--db-address",
-                "jdbc:hsqldb:mem:my-animalclinic.example",
+                "jdbc:hsqldb:mem:my-db12.example",
                 "--output",
                 outputPath.toString(),
                 "--sql-scripts",
@@ -423,7 +423,7 @@ public final class ExtractSubcommandTest {
     assertThat(
             cmd.execute(
                 "--db-address",
-                "jdbc:hsqldb:mem:my-animalclinic.example",
+                "jdbc:hsqldb:mem:my-db13.example",
                 "--output",
                 outputPath.toString(),
                 "--sql-scripts",
@@ -442,7 +442,7 @@ public final class ExtractSubcommandTest {
     assertThat(
             cmd.execute(
                 "--db-address",
-                "jdbc:hsqldb:mem:my-animalclinic.example",
+                "jdbc:hsqldb:mem:my-db14.example",
                 "--output",
                 outputPath.toString(),
                 "--skip-sql-scripts",
@@ -472,7 +472,7 @@ public final class ExtractSubcommandTest {
     assertThat(
             cmd.execute(
                 "--db-address",
-                "jdbc:hsqldb:mem:my-animalclinic.example",
+                "jdbc:hsqldb:mem:my-db15.example",
                 "--output",
                 "/does/not/exist"))
         .isEqualTo(2);
@@ -490,7 +490,7 @@ public final class ExtractSubcommandTest {
     assertThat(
             cmd.execute(
                 "--db-address",
-                "jdbc:hsqldb:mem:my-animalclinic.example",
+                "jdbc:hsqldb:mem:my-db16.example",
                 "--output",
                 "/does/not/exist/out.zip"))
         .isEqualTo(2);
@@ -521,7 +521,7 @@ public final class ExtractSubcommandTest {
 
     assertThat(
             cmd.execute(
-                "--db-address", "jdbc:hsqldb:mem:my-animalclinic.example",
+                "--db-address", "jdbc:hsqldb:mem:my-db17.example",
                 "--output", outputPath.toString(),
                 "--script-base-db", "foo=bar"))
         .isEqualTo(2);


### PR DESCRIPTION
db-password has an interactive mode so not marking it required.

Also fixed ExtractSubcommandTest subtests to use different in-memory database URIs so that the tests don't interfere with each other