### PR TITLE
Revert changes of using QryLogObjectsV instead of DBQLObjTbl

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ the Extraction tool binary (i.e., ExtractionTool_deploy.jar) and its run script.
   - [FunctionsV](https://docs.teradata.com/r/oiS9ixs2ypIQvjTUOJfgoA/hx9hvPb9EvS6TP9Ta2PUzQ)
   - [IndicesV](https://docs.teradata.com/r/oiS9ixs2ypIQvjTUOJfgoA/qkWdqMUH7HZaIkY_pSQUng)
   - [PartitioningConstraintsV](https://docs.teradata.com/r/oiS9ixs2ypIQvjTUOJfgoA/G5eOtdk_Z5xjAgAderQlQg)
-  - [QryLogObjectsV](https://docs.teradata.com/r/oiS9ixs2ypIQvjTUOJfgoA/FvQHxfqfQIWCkPhL9vlYvw)
+  - [DBQLObjTbl](https://docs.teradata.com/r/B7Lgdw6r3719WUyiCSJcgw/eOMXq~u5PwRV5GrooD6_9A)
   - [QryLogV](https://docs.teradata.com/r/oiS9ixs2ypIQvjTUOJfgoA/sT8ifzajeQ9jMx7ciiu1dA)
   - [QryLogSQLV](https://docs.teradata.com/r/oiS9ixs2ypIQvjTUOJfgoA/SQqDiRkDlOLYNSZ4dBRIGQ)
   - [RoleMembersV](https://docs.teradata.com/r/oiS9ixs2ypIQvjTUOJfgoA/y5EHNeWIu1uFk5714KHTaw)

--- a/src/java/com/google/cloud/bigquery/dwhassessment/extractiontool/dbscripts/query_references.sql
+++ b/src/java/com/google/cloud/bigquery/dwhassessment/extractiontool/dbscripts/query_references.sql
@@ -24,8 +24,8 @@ SELECT
   "ObjectType",
   "FreqofUse",
   "TypeofUse"
-FROM "{{baseDatabase}}"."{{#if vars.tableName}}{{vars.tableName}}{{else}}QryLogObjectsV{{/if}}"
+FROM "{{baseDatabase}}"."{{#if vars.tableName}}{{vars.tableName}}{{else}}DBQLObjTbl{{/if}}"
 {{#if queryLogsVariables.timeRange}}
-WHERE "{{baseDatabase}}"."{{#if vars.tableName}}{{vars.tableName}}{{else}}QryLogObjectsV{{/if}}"."CollectTimeStamp"
+WHERE "{{baseDatabase}}"."{{#if vars.tableName}}{{vars.tableName}}{{else}}DBQLObjTbl{{/if}}"."CollectTimeStamp"
   BETWEEN TIMESTAMP '{{queryLogsVariables.timeRange.startTimestamp}}' AND TIMESTAMP '{{queryLogsVariables.timeRange.endTimestamp}}'
 {{/if}}

--- a/src/javatests/com/google/cloud/bigquery/dwhassessment/extractiontool/dbscripts/test_data.sql
+++ b/src/javatests/com/google/cloud/bigquery/dwhassessment/extractiontool/dbscripts/test_data.sql
@@ -641,7 +641,7 @@ VALUES (
   0
 );
 
-INSERT INTO DBC."QryLogObjectsV" (
+INSERT INTO DBC."DBQLObjTbl" (
   "ProcID",
   "CollectTimeStamp",
   "QueryID",

--- a/src/javatests/com/google/cloud/bigquery/dwhassessment/extractiontool/faketd/teradata_tables.sql
+++ b/src/javatests/com/google/cloud/bigquery/dwhassessment/extractiontool/faketd/teradata_tables.sql
@@ -342,7 +342,7 @@ CREATE TABLE DBC."PartitioningConstraintsV" (
   "ColumnPartitioningLevel" SMALLINT NOT NULL,
 );
 
-CREATE TABLE DBC."QryLogObjectsV" (
+CREATE TABLE DBC."DBQLObjTbl" (
   "ProcID" DECIMAL(5,0) NOT NULL,
   "CollectTimeStamp" TIMESTAMP(6) NOT NULL,
   "QueryID" DECIMAL(18,0) NOT NULL,


### PR DESCRIPTION
Starting from Teradata 16, `TypeofUse` field in `QryLogObjectsV` has different type than `DBQLObjTbl` and provides an explanation over possible values, e.g. "70: Access, conditional, full outer join" instead of 70. 

We have similar functionality to map bit values to types during assessment, so I revert everything back to use `DBQLObjTbl` raw bit values.

```sql
SHOW VIEW QryLogObjectsV;

 *** Text of DDL statement returned.
 *** Total elapsed time was 1 second.

---------------------------------------------------------------------------
REPLACE VIEW DBC.QryLogObjectsV
AS
LOCKING TABLE DBC.DBQLObjTbl FOR ACCESS
SELECT
     ProcID,
     CollectTimeStamp,
     QueryID ( FORMAT '--Z(17)9'),
     ObjectDatabaseName,
     ObjectTableName,
     ObjectColumnName,
     ObjectID,
     ObjectNum,
     ObjectType,
     FreqofUse,
     CASE TypeOfUse
         WHEN  1 THEN  '  1: Reference only'
         WHEN  2 THEN  '  2: Access'
         WHEN  3 THEN  '  3: Reference, access'
         WHEN  6 THEN  '  6: Access, conditional'
         WHEN  7 THEN  '  7: Reference, access, conditional'
         WHEN 10 THEN  ' 10: Access, inner join'
         WHEN 14 THEN  ' 14: Access, conditional, inner join'
         WHEN 18 THEN  ' 18: Access, outer join'
         WHEN 22 THEN  ' 22: Access, conditional, outer join'
         WHEN 30 THEN  ' 30: Access, conditional, inner and outer join'
         WHEN 34 THEN  ' 34: Access, sum'
         WHEN 38 THEN  ' 38: Access, conditional, sum'
         WHEN 46 THEN  ' 46: Access, conditional, sum, inner join'
         WHEN 54 THEN  ' 54: Access, conditional, sum, outer join'
         WHEN 70 THEN  ' 70: Access, conditional, full outer join'
         WHEN 102 THEN '102: Access, conditional, sum, full outer join'

         ELSE TypeOfUse
     END (NAMED TypeOfUse)
FROM DBC.DBQLObjTbl;
```