### PR TITLE
fix extracting tabletext.sql

### DIFF
--- a/src/java/com/google/cloud/bigquery/dwhassessment/extractiontool/dbscripts/InternalScriptLoader.java
+++ b/src/java/com/google/cloud/bigquery/dwhassessment/extractiontool/dbscripts/InternalScriptLoader.java
@@ -48,6 +48,7 @@ public class InternalScriptLoader implements ScriptLoader {
           "stats",
           "tableinfo",
           "tablesize",
+          "tabletext",
           "temp_tables",
           "users");
 

--- a/src/javatests/com/google/cloud/bigquery/dwhassessment/extractiontool/dbscripts/InternalScriptLoaderTest.java
+++ b/src/javatests/com/google/cloud/bigquery/dwhassessment/extractiontool/dbscripts/InternalScriptLoaderTest.java
@@ -570,6 +570,29 @@ public class InternalScriptLoaderTest {
   }
 
   @Test
+  public void loadScripts_tableText() throws IOException, SQLException {
+    String scriptName = "tabletext";
+    String sqlScript = getScript(scriptName);
+    // Get schema and verify records.
+    Schema schema = scriptRunner.extractSchema(connection, sqlScript, scriptName, "namespace");
+    ImmutableList<GenericRecord> records = executeScriptToAvro(/*sqlScript=*/ sqlScript, schema);
+    GenericRecord expectedRecord =
+        new GenericRecordBuilder(schema)
+            .set("DatabaseName", "test_database")
+            .set("TableName", "test_table")
+            .set("TableKind", "V")
+            .set("RequestText", "test_request_text")
+            .set("LineNo", 1)
+            .build();
+    assertThat(records).containsExactly(expectedRecord);
+
+    // Verify records serialization.
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    executeScript(scriptName, outputStream);
+    assertThat(getAvroDataOutputReader(outputStream).next()).isEqualTo(expectedRecord);
+  }
+
+  @Test
   public void loadScripts_columns() throws IOException, SQLException {
     String scriptName = "columns";
     String sqlScript = getScript(scriptName);


### PR DESCRIPTION
I missed to add the new sql file name to ScriptLoader in https://github.com/google/dwh-assessment-extraction-tool/pull/88. Fixed it.