### PR TITLE
Allow to skip JDBC schema extraction

### DIFF
--- a/src/java/com/google/cloud/bigquery/dwhassessment/extractiontool/executor/ExtractExecutor.java
+++ b/src/java/com/google/cloud/bigquery/dwhassessment/extractiontool/executor/ExtractExecutor.java
@@ -63,6 +63,9 @@ public interface ExtractExecutor {
     /** SQL scripts to exclude (i.e., run the full catalog except for these scripts). */
     public abstract ImmutableList<String> skipSqlScripts();
 
+    /** Extract schemas via JDBC. */
+    public abstract boolean needJdbcSchemas();
+
     /** Filter to apply on schemas to extract */
     public abstract ImmutableList<SchemaFilter> schemaFilters();
 
@@ -90,6 +93,7 @@ public interface ExtractExecutor {
           .setMode(RunMode.NORMAL)
           .setScriptVariables(ImmutableMap.of())
           .setScriptBaseDatabase(ImmutableMap.of())
+          .setNeedJdbcSchemas(true)
           .setSchemaFilters(ImmutableList.of())
           .setSqlScripts(ImmutableList.of())
           .setSkipSqlScripts(ImmutableList.of());
@@ -113,6 +117,8 @@ public interface ExtractExecutor {
 
       public abstract Builder setScriptVariables(
           ImmutableMap<String, Map<String, String>> variables);
+
+      public abstract Builder setNeedJdbcSchemas(boolean needJdbcSchemas);
 
       public abstract Builder setSchemaFilters(List<SchemaFilter> schemaFilters);
 

--- a/src/java/com/google/cloud/bigquery/dwhassessment/extractiontool/executor/ExtractExecutorImpl.java
+++ b/src/java/com/google/cloud/bigquery/dwhassessment/extractiontool/executor/ExtractExecutorImpl.java
@@ -157,7 +157,9 @@ public final class ExtractExecutorImpl implements ExtractExecutor {
       LOGGER.log(Level.INFO, "Finished extracting {0}.", scriptName);
     }
 
-    if (arguments.dryRun()) {
+    if (!arguments.needJdbcSchemas()) {
+      LOGGER.log(Level.INFO, "Skipping extracting schemas was requested.");
+    } else if (arguments.dryRun()) {
       LOGGER.log(Level.INFO, "Skipping extracting schemas because dry run was requested.");
     } else {
       LOGGER.log(Level.INFO, "Start extracting schemas");

--- a/src/java/com/google/cloud/bigquery/dwhassessment/extractiontool/subcommand/ExtractSubcommand.java
+++ b/src/java/com/google/cloud/bigquery/dwhassessment/extractiontool/subcommand/ExtractSubcommand.java
@@ -293,8 +293,7 @@ public final class ExtractSubcommand implements Callable<Integer> {
   @Option(
       names = "--need-jdbc-schemas",
       negatable = true,
-      description = "Whether to extract schemas through JDBC. Default: ${DEFAULT-VALUE}"
-  )
+      description = "Whether to extract schemas through JDBC. Default: ${DEFAULT-VALUE}")
   private boolean needJdbcSchemas = true;
 
   @Option(
@@ -344,8 +343,7 @@ public final class ExtractSubcommand implements Callable<Integer> {
       Path path = Paths.get(prevRunPathString);
       if (path.toString().endsWith(".zip")) {
         throw new ParameterException(
-            spec.commandLine(),
-            "Incremental mode is not supported for zipped records, yet.");
+            spec.commandLine(), "Incremental mode is not supported for zipped records, yet.");
       }
       if (!Files.isDirectory(path)) {
         throw new ParameterException(

--- a/src/java/com/google/cloud/bigquery/dwhassessment/extractiontool/subcommand/ExtractSubcommand.java
+++ b/src/java/com/google/cloud/bigquery/dwhassessment/extractiontool/subcommand/ExtractSubcommand.java
@@ -291,6 +291,13 @@ public final class ExtractSubcommand implements Callable<Integer> {
   }
 
   @Option(
+      names = "--need-jdbc-schemas",
+      negatable = true,
+      description = "Whether to extract schemas through JDBC. Default: ${DEFAULT-VALUE}"
+  )
+  private boolean needJdbcSchemas = true;
+
+  @Option(
       names = "--schema-filter",
       description = {
         "The schema filter to apply when extracting schemas from the database.",

--- a/src/javatests/com/google/cloud/bigquery/dwhassessment/extractiontool/executor/ExtractExecutorImplTest.java
+++ b/src/javatests/com/google/cloud/bigquery/dwhassessment/extractiontool/executor/ExtractExecutorImplTest.java
@@ -123,6 +123,42 @@ public final class ExtractExecutorImplTest {
   }
 
   @Test
+  public void run_skipJdbcSchemaExtraction_success() throws Exception {
+    when(scriptManager.getAllScriptNames()).thenReturn(ImmutableSet.of());
+
+    assertThat(
+        executor.run(
+            ExtractExecutor.Arguments.builder()
+                .setDbConnectionProperties(properties)
+                .setDbConnectionAddress("jdbc:hsqldb:mem:my-animalclinic.example")
+                .setOutputPath(Paths.get("/tmp"))
+                .setNeedJdbcSchemas(false)
+                .build()))
+        .isEqualTo(0);
+
+    verifyNoMoreInteractions(schemaManager);
+  }
+
+  @Test
+  public void run_extractJdbcSchemas_success() throws Exception {
+    when(scriptManager.getAllScriptNames()).thenReturn(ImmutableSet.of());
+    when(schemaManager.getSchemaKeys(any(Connection.class), eq(ImmutableList.of())))
+        .thenReturn(ImmutableSet.of());
+
+    assertThat(
+        executor.run(
+            ExtractExecutor.Arguments.builder()
+                .setDbConnectionProperties(properties)
+                .setDbConnectionAddress("jdbc:hsqldb:mem:my-animalclinic.example")
+                .setOutputPath(Paths.get("/tmp"))
+                .build()))
+        .isEqualTo(0);
+
+    verify(schemaManager).getSchemaKeys(any(Connection.class), eq(ImmutableList.of()));
+    verifyNoMoreInteractions(schemaManager);
+  }
+
+  @Test
   public void run_incrementalMode_success() throws Exception {
     when(scriptManager.getAllScriptNames())
         .thenReturn(ImmutableSet.of("test_script_0", "test_script_1"));

--- a/src/javatests/com/google/cloud/bigquery/dwhassessment/extractiontool/executor/ExtractExecutorImplTest.java
+++ b/src/javatests/com/google/cloud/bigquery/dwhassessment/extractiontool/executor/ExtractExecutorImplTest.java
@@ -19,8 +19,8 @@ import static com.google.cloud.bigquery.dwhassessment.extractiontool.executor.Ex
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -40,7 +40,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.re2j.Pattern;
 import java.io.ByteArrayOutputStream;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.sql.Connection;
 import java.time.Instant;
@@ -127,13 +126,13 @@ public final class ExtractExecutorImplTest {
     when(scriptManager.getAllScriptNames()).thenReturn(ImmutableSet.of());
 
     assertThat(
-        executor.run(
-            ExtractExecutor.Arguments.builder()
-                .setDbConnectionProperties(properties)
-                .setDbConnectionAddress("jdbc:hsqldb:mem:my-animalclinic.example")
-                .setOutputPath(Paths.get("/tmp"))
-                .setNeedJdbcSchemas(false)
-                .build()))
+            executor.run(
+                ExtractExecutor.Arguments.builder()
+                    .setDbConnectionProperties(properties)
+                    .setDbConnectionAddress("jdbc:hsqldb:mem:my-animalclinic.example")
+                    .setOutputPath(Paths.get("/tmp"))
+                    .setNeedJdbcSchemas(false)
+                    .build()))
         .isEqualTo(0);
 
     verifyNoMoreInteractions(schemaManager);
@@ -146,12 +145,12 @@ public final class ExtractExecutorImplTest {
         .thenReturn(ImmutableSet.of());
 
     assertThat(
-        executor.run(
-            ExtractExecutor.Arguments.builder()
-                .setDbConnectionProperties(properties)
-                .setDbConnectionAddress("jdbc:hsqldb:mem:my-animalclinic.example")
-                .setOutputPath(Paths.get("/tmp"))
-                .build()))
+            executor.run(
+                ExtractExecutor.Arguments.builder()
+                    .setDbConnectionProperties(properties)
+                    .setDbConnectionAddress("jdbc:hsqldb:mem:my-animalclinic.example")
+                    .setOutputPath(Paths.get("/tmp"))
+                    .build()))
         .isEqualTo(0);
 
     verify(schemaManager).getSchemaKeys(any(Connection.class), eq(ImmutableList.of()));


### PR DESCRIPTION
Add on option to skip JDBC schema extraction altogether to avoid
having any schema related JDBC calls that would otherwise happen
to find out what schemas exist.

Change-Id: I575e32507430f8203d587bba06edda1f6242105e