### PR TITLE
Fix --(no-)need-jdbc-schemas flag

### DIFF
--- a/src/java/com/google/cloud/bigquery/dwhassessment/extractiontool/subcommand/ExtractSubcommand.java
+++ b/src/java/com/google/cloud/bigquery/dwhassessment/extractiontool/subcommand/ExtractSubcommand.java
@@ -307,7 +307,7 @@ public final class ExtractSubcommand implements Callable<Integer> {
       names = "--need-jdbc-schemas",
       negatable = true,
       description = "Whether to extract schemas through JDBC. Default: ${DEFAULT-VALUE}")
-  private boolean needJdbcSchemas = true;
+  private Boolean needJdbcSchemas;
 
   @Option(
       names = "--schema-filter",
@@ -341,9 +341,12 @@ public final class ExtractSubcommand implements Callable<Integer> {
   }
 
   private ExtractExecutor.Arguments getValidatedArguments() {
-    argumentsBuilder.setNeedQueryText(true);
+    argumentsBuilder.setNeedQueryText(true).setNeedJdbcSchemas(true);
     if (needQueryText != null) {
       argumentsBuilder.setNeedQueryText(needQueryText);
+    }
+    if (needJdbcSchemas != null) {
+      argumentsBuilder.setNeedJdbcSchemas(needJdbcSchemas);
     }
     // prevRunPath is set only when the specified mode is not NORMAL.
     if (mode.equals(RunMode.INCREMENTAL)) {

--- a/src/javatests/com/google/cloud/bigquery/dwhassessment/extractiontool/subcommand/ExtractSubcommandTest.java
+++ b/src/javatests/com/google/cloud/bigquery/dwhassessment/extractiontool/subcommand/ExtractSubcommandTest.java
@@ -202,6 +202,56 @@ public final class ExtractSubcommandTest {
   }
 
   @Test
+  public void call_successWithNoNeedJdbcSchemas() throws IOException, SQLException {
+    ExtractExecutor executor = Mockito.mock(ExtractExecutor.class);
+    CommandLine cmd = new CommandLine(new ExtractSubcommand(() -> executor, scriptManager));
+    ArgumentCaptor<ExtractExecutor.Arguments> argumentsCaptor =
+        ArgumentCaptor.forClass(ExtractExecutor.Arguments.class);
+
+    assertThat(
+            cmd.execute(
+                "--db-address",
+                "jdbc:hsqldb:mem:db-noneedjdbcschemas",
+                "--db-user",
+                "my-username",
+                "--db-password",
+                "my0password",
+                "--output",
+                outputPath.toString(),
+                "--need-jdbc-schemas=false"))
+        .isEqualTo(0);
+
+    verify(executor).run(argumentsCaptor.capture());
+    ExtractExecutor.Arguments arguments = argumentsCaptor.getValue();
+    assertThat(arguments.needJdbcSchemas()).isFalse();
+  }
+
+  @Test
+  public void call_successWithNegatedNeedJdbcSchemas() throws IOException, SQLException {
+    ExtractExecutor executor = Mockito.mock(ExtractExecutor.class);
+    CommandLine cmd = new CommandLine(new ExtractSubcommand(() -> executor, scriptManager));
+    ArgumentCaptor<ExtractExecutor.Arguments> argumentsCaptor =
+        ArgumentCaptor.forClass(ExtractExecutor.Arguments.class);
+
+    assertThat(
+            cmd.execute(
+                "--db-address",
+                "jdbc:hsqldb:mem:db-negatedneedjdbcschemas",
+                "--db-user",
+                "my-username",
+                "--db-password",
+                "my0password",
+                "--output",
+                outputPath.toString(),
+                "--no-need-jdbc-schemas"))
+        .isEqualTo(0);
+
+    verify(executor).run(argumentsCaptor.capture());
+    ExtractExecutor.Arguments arguments = argumentsCaptor.getValue();
+    assertThat(arguments.needJdbcSchemas()).isFalse();
+  }
+
+  @Test
   public void call_successWithSkipSqlScripts() throws IOException, SQLException {
     ExtractExecutor executor = Mockito.mock(ExtractExecutor.class);
     CommandLine cmd = new CommandLine(new ExtractSubcommand(() -> executor, scriptManager));


### PR DESCRIPTION
caused by picocli's quirks with "negatable=true" boolean flags.