### PR TITLE
Print a final end message to the logs

### DIFF
--- a/src/java/com/google/cloud/bigquery/dwhassessment/extractiontool/executor/ExtractExecutorImpl.java
+++ b/src/java/com/google/cloud/bigquery/dwhassessment/extractiontool/executor/ExtractExecutorImpl.java
@@ -174,6 +174,7 @@ public final class ExtractExecutorImpl implements ExtractExecutor {
     }
 
     dataEntityManager.close();
+    LOGGER.log(Level.INFO, "Finished extraction.");
     return 0;
   }
 


### PR DESCRIPTION
This prints a final message to show that the program exited normally. Otherwise to logs might look like the program crashed when there was a warning at the end.

Change-Id: I1f58a7404767d03dc225eb799eda7d1ed85d28a8