### PR TITLE
Fix parameter parsing in the run-td-extract script

### DIFF
--- a/src/scripts/run-td-extract.sh
+++ b/src/scripts/run-td-extract.sh
@@ -106,6 +106,6 @@ fi
 args+=($@)
 
 CLASSPATH="$(dirname "$0")/ExtractionTool_deploy.jar:${TERAJDBC4_JAR}"
-echo java -cp "${CLASSPATH}" \
+java -cp "${CLASSPATH}" \
   com/google/cloud/bigquery/dwhassessment/extractiontool/ExtractionTool \
   td-extract "${args[@]}"

--- a/src/scripts/run-td-extract.sh
+++ b/src/scripts/run-td-extract.sh
@@ -64,6 +64,13 @@ case $key in
     shift # past argument
     shift # past value
     ;;
+    --)
+    shift
+    break 2
+    ;;
+    *)
+    echo "Unknown parameter $1."
+    exit 1
 esac
 done
 
@@ -96,7 +103,9 @@ if [[ -n "${SKIP_SQL_SCRIPTS}" ]]; then
     args+=( --skip-sql-scripts "${SKIP_SQL_SCRIPTS}" )
 fi
 
+args+=($@)
+
 CLASSPATH="$(dirname "$0")/ExtractionTool_deploy.jar:${TERAJDBC4_JAR}"
-java -cp "${CLASSPATH}" \
+echo java -cp "${CLASSPATH}" \
   com/google/cloud/bigquery/dwhassessment/extractiontool/ExtractionTool \
   td-extract "${args[@]}"


### PR DESCRIPTION
The `run-td-extract` script has an endless loop if encountering an unknown parameter.

This change exits when encountering unknown parameters and allows to hand through parameters to `td-extract` by using `--`.